### PR TITLE
error handling, not returning response_json on errors

### DIFF
--- a/contextio/__init__.py
+++ b/contextio/__init__.py
@@ -224,7 +224,7 @@ class ContextIO(object):
             except ValueError:
                 return response.text
         else:
-            self._handle_request_error(response)
+            return self._handle_request_error(response)
 
     def _request(self, url, method, params, headers={}, body=''):
         """This method actually makes the request using the oauth client.
@@ -277,6 +277,8 @@ class ContextIO(object):
                 )
         else:
             raise Exception(response.text)
+        
+        return response_json
 
     def get_accounts(self, **params):
         """List of Accounts.


### PR DESCRIPTION
We faced some issues when handling errors with python wrapper for context.io, after some investigation @elmkarami found that the response is not being returned to `.get_source()` when there is an error.

Please review suggested pull request 