### PR TITLE
Modified error handling

### DIFF
--- a/contextio/lib/v2_0/errors.py
+++ b/contextio/lib/v2_0/errors.py
@@ -1,10 +1,6 @@
 class ArgumentError(Exception):
     """Class to handle bad arguments."""
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return self.message
+    pass
 
 class MissingResourceId(Exception):
     """Class to handle missing required argument on resource init."""

--- a/contextio/lib/v2_0/helpers.py
+++ b/contextio/lib/v2_0/helpers.py
@@ -100,10 +100,8 @@ def sanitize_params(params, all_args, required_args=None):
 
         # yell if we're missing a required argument
         if missing_required_args:
-            raise ArgumentError(
-                'Missing the following required arguments: %s' \
-                % ', '.join(missing_required_args)
-            )
+            raise ArgumentError("Missing the following required arguments: {0}".format(
+                ", ".join(missing_required_args)))
 
     # remove any arguments not recognized
     cleaned_args = {}
@@ -115,7 +113,6 @@ def sanitize_params(params, all_args, required_args=None):
     # quietly yell in a non-breaking way if there's any unrecognized
     # arguments left
     if params:
-        logging.warning('Invalid arguments found: %s' % \
-            ', '.join(param for param in params))
+        logging.warning("Invalid arguments found: %s".format(", ".join(param for param in params)))
 
     return cleaned_args


### PR DESCRIPTION

Modified the way HTTP errors are being handled - pass through the body of the error in case there is a helpful message from the API

- HTTP Errors are using the HTTPError class from the requests library
- small style and format cleanup