### PR TITLE
adding params needed for updating an existing webhook

### DIFF
--- a/contextio/lib/resources/webhook.py
+++ b/contextio/lib/resources/webhook.py
@@ -100,10 +100,13 @@ class WebHook(BaseResource):
         Returns:
             Bool
         """
-        req_args = ["active"]
-        all_args = ["active"]
+        all_args = ["callback_url", "failure_notif_url", "active",
+        "filter_to", "filter_from", "filter_cc",
+        "filter_subject", "filter_thread", "filter_new_important",
+        "filter_file_name", "filter_folder_added", "filter_folder_removed",
+        "filter_to_domain", "filter_from_domain"]
 
-        return super(WebHook, self).post(params=params, all_args=all_args, required_args=req_args)
+        return super(WebHook, self).post(params=params, all_args=all_args)
 
     def delete(self):
         """Delete a webhook.


### PR DESCRIPTION
You can now edit an existing webhook via POST webhook/:id

In the past, you could only set a webhook to active/inactive via POST webhook/:id. Now you can edit an existing webhook via this endpoint. I added the needed params for this to the WebHook post() method. No params are required, all are optional now.