### PR TITLE
posting to a source with force_status_check would fail because the re…

### DIFF
--- a/contextio/lib/resources/base_resource.py
+++ b/contextio/lib/resources/base_resource.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from .. import helpers
+from ..errors import MissingResourceId
 import functools
 import logging
 import six
@@ -9,10 +11,8 @@ if six.PY2:
 else:
     from urllib.parse import quote
 
-from .. import helpers
-from ..errors import MissingResourceId
-
 no_resource_id_required = ["BaseResource", "Discovery"]
+
 
 def only(*versions):
     def _only(method):
@@ -25,6 +25,7 @@ def only(*versions):
             return method(self, *args, **kwargs)
         return wrapper
     return _only
+
 
 class BaseResource(object):
     """Base class for resource objects."""
@@ -100,14 +101,14 @@ class BaseResource(object):
 
     def delete(self, uri=""):
         response = self._request_uri(uri, method='DELETE')
-        return bool(response['success'])
+        return bool(response.get('success', False))
 
     def post(self, uri="", return_bool=True, params={}, headers={}, all_args=[], required_args=[]):
         params = helpers.sanitize_params(params, all_args, required_args)
         response = self._request_uri(uri, method="POST", params=params, headers=headers)
 
         if return_bool:
-            return bool(response['success'])
+            return bool(response.get('success', False))
 
         return response
 

--- a/contextio/lib/resources/base_resource.py
+++ b/contextio/lib/resources/base_resource.py
@@ -108,7 +108,10 @@ class BaseResource(object):
         response = self._request_uri(uri, method="POST", params=params, headers=headers)
 
         if return_bool:
-            return bool(response.get('success', False))
+            if 'success' in response:
+                return bool(response.get('success', False))
+            if 'status' in response:
+                return True if response.get('status') == 'OK' else False
 
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requires=['rauth', 'six']
 
 setup(name='contextio',
-    version='v1.12.0',
+    version='v1.12.1',
     description='Library for accessing the Context.IO API (v2.0 and Lite) in Python',
     author='Alex Tanton, Cecy Correa',
     author_email='alex.tanton@returnpath.com, cecy.correa@returnpath.com',

--- a/tests/lib/resources/test_base_resource.py
+++ b/tests/lib/resources/test_base_resource.py
@@ -123,7 +123,7 @@ class TestBaseResource(unittest.TestCase):
 
     @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
     def test_delete_returns_boolean(self, mock_request):
-        mock_request.return_value = {"success": 'true'}
+        mock_request.return_value = {"success": True}
         base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
         response = base_resource.delete()
 
@@ -131,7 +131,7 @@ class TestBaseResource(unittest.TestCase):
 
     @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
     def test_post_returns_boolean_by_default(self, mock_request):
-        mock_request.return_value = {"success": 'true'}
+        mock_request.return_value = {"success": True}
         base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
         response = base_resource.post()
 
@@ -139,7 +139,7 @@ class TestBaseResource(unittest.TestCase):
 
     @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
     def test_post_returns_false_if_success_not_in_response(self, mock_request):
-        mock_request.return_value = {"nope": 'true'}
+        mock_request.return_value = {"nope": True}
         base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
         response = base_resource.post()
 

--- a/tests/lib/resources/test_base_resource.py
+++ b/tests/lib/resources/test_base_resource.py
@@ -123,26 +123,35 @@ class TestBaseResource(unittest.TestCase):
 
     @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
     def test_delete_returns_boolean(self, mock_request):
-        mock_request.return_value = {"success": True}
+        mock_request.return_value = {"success": 'true'}
         base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
         response = base_resource.delete()
 
-        self.assertEqual(True, response)
-
-    # @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
-    # def test_post_sends_post_request_with_defaults_to_resource_base_uri(self, mock_request):
-    #     base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
-    #     base_resource.post()
-
-    #     mock_request.assert_called_with('', headers={}, method='POST', params={})
+        self.assertTrue(response)
 
     @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
     def test_post_returns_boolean_by_default(self, mock_request):
-        mock_request.return_value = {"success": True}
+        mock_request.return_value = {"success": 'true'}
         base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
         response = base_resource.post()
 
-        self.assertEqual(True, response)
+        self.assertTrue(response)
+
+    @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
+    def test_post_returns_false_if_success_not_in_response(self, mock_request):
+        mock_request.return_value = {"nope": 'true'}
+        base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
+        response = base_resource.post()
+
+        self.assertFalse(response)
+
+    @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
+    def test_post_returns_false_if_success_is_false(self, mock_request):
+        mock_request.return_value = {"nope": 'false'}
+        base_resource = BaseResource(Mock(), "test/{id}", {"id": "fake_id"})
+        response = base_resource.post()
+
+        self.assertFalse(response)
 
     @patch("contextio.lib.resources.base_resource.BaseResource._request_uri")
     def test_post_returns_body_of_response_if_return_bool_False(self, mock_request):
@@ -151,4 +160,3 @@ class TestBaseResource(unittest.TestCase):
         response = base_resource.post(return_bool=False)
 
         self.assertEqual({"success": True}, response)
-


### PR DESCRIPTION
…sponse is slightly different than other endpoints that behave this way.  We now check for the keys 'success' and 'status' before returning

@DaneCarmichael @AaronLaBrie 