### PR TITLE
add deprecation notice, make Lite the default client

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This is the python client library the Context.IO API (Lite and v2.0)!
 
 Supports Python 2.7 (2.7.9 and up) and 3.
 
+### NOTICE
+The 2.0 version of the API will be partially deprecated starting on June 15th, 2018, and will be completely deprecated on December 15th, 2018.
+
+[https://blog.context.io/important-announcement-deprecation-of-2-0-api-8f73488a8c0e](READ MORE HERE)
+
 ##Dependencies
 If you plan on contributing to this project you will want to clone this repo and then use `pip` to install the dependencies.
 

--- a/contextio/contextio.py
+++ b/contextio/contextio.py
@@ -10,4 +10,4 @@ def ContextIO(consumer_key, consumer_secret, **kwargs):
     elif kwargs.get("api_version") == "app":
     	return App(consumer_key, consumer_secret, **kwargs)
     else:
-        return V2_0(consumer_key, consumer_secret, **kwargs)
+        return Lite(consumer_key, consumer_secret, **kwargs)


### PR DESCRIPTION
2.0 is being deprecated:

* Add deprecation notice to README
* Make Lite the default factory instead of 2.0